### PR TITLE
Web app: browser-side decode, empty cards in stitch, table pagination

### DIFF
--- a/monsterbook/src/app.rs
+++ b/monsterbook/src/app.rs
@@ -204,7 +204,7 @@ impl<'a> epi::App for App {
                     thread::spawn(move || {
                         let iter = pages.iter().map(|(id, page)| (*id, page));
                         if let Some(image) =
-                            pipeline::stitch_page_cards(iter, cards_per_row, &WIN_HD)
+                            pipeline::stitch_page_cards(iter, cards_per_row, false, &WIN_HD)
                         {
                             sender.send((image, tag)).unwrap();
                         }

--- a/monsterbook/src/pipeline.rs
+++ b/monsterbook/src/pipeline.rs
@@ -88,10 +88,16 @@ pub fn extract_cards(pages: &[Image], layout: &Layout) -> Vec<Card> {
         .collect()
 }
 
-/// Stitch the non-empty cards of (page_id, page) pairs into a single image,
-/// replacing each card's background with the page's tab color. Returns None
-/// when there are no non-empty cards to stitch.
-pub fn stitch_page_cards<'a, I>(pages: I, per_row: u32, layout: &Layout) -> Option<Image>
+/// Stitch the cards of (page_id, page) pairs into a single image, replacing
+/// each card's background with the page's tab color. Empty (un-caught) card
+/// slots are skipped unless `include_empty` is set. Returns None when there
+/// are no cards to stitch.
+pub fn stitch_page_cards<'a, I>(
+    pages: I,
+    per_row: u32,
+    include_empty: bool,
+    layout: &Layout,
+) -> Option<Image>
 where
     I: IntoIterator<Item = (usize, &'a Image)>,
 {
@@ -99,11 +105,14 @@ where
     let cards: Vec<Image> = pages
         .into_iter()
         .flat_map(|(page_id, page)| {
+            // The grid has more slots than some pages have cards; slots past
+            // the page's card_count are not real cards and never stitch.
             vision::crop_cards(page, layout)
                 .into_iter()
+                .take(book.pages[page_id].card_count)
                 .map(move |image| (page_id, image))
         })
-        .filter(|(_, image)| card_mse(image) > layout.empty_mse_threshold)
+        .filter(|(_, image)| include_empty || card_mse(image) > layout.empty_mse_threshold)
         .map(|(page_id, mut image)| {
             let color = get_color(&book.pages[page_id].tab_color);
             vision::replace_background(&mut image, color, layout);
@@ -120,7 +129,7 @@ where
 /// background with its tab color. Pages are assumed to be in book order
 /// starting at page 0.
 pub fn stitch_cards(pages: &[Image], per_row: u32, layout: &Layout) -> Image {
-    stitch_page_cards(pages.iter().enumerate(), per_row, layout)
+    stitch_page_cards(pages.iter().enumerate(), per_row, false, layout)
         .unwrap_or_else(|| Image::new(0, 0))
 }
 

--- a/monsterbook/src/session.rs
+++ b/monsterbook/src/session.rs
@@ -127,12 +127,14 @@ impl Session {
             .collect()
     }
 
-    /// Stitch the non-empty cards of the ingested pages, in page order. None
-    /// when the session is empty (or has no non-empty cards).
-    pub fn stitch(&self, cards_per_row: u32) -> Option<Image> {
+    /// Stitch the cards of the ingested pages, in page order. Empty
+    /// (un-caught) card slots are skipped unless `include_empty` is set.
+    /// None when the session is empty (or has no cards to stitch).
+    pub fn stitch(&self, cards_per_row: u32, include_empty: bool) -> Option<Image> {
         pipeline::stitch_page_cards(
             self.pages.iter().map(|(&id, page)| (id, page)),
             cards_per_row,
+            include_empty,
             self.layout,
         )
     }
@@ -276,10 +278,12 @@ mod tests {
     #[test]
     fn test_stitch() {
         let mut session = Session::new();
-        assert!(session.stitch(10).is_none());
+        assert!(session.stitch(10, false).is_none());
         // an ingested empty reference page has no non-empty cards either
         session.add_screenshot(&encoded_reference(0)).unwrap();
-        assert!(session.stitch(10).is_none());
+        assert!(session.stitch(10, false).is_none());
+        // ...unless empty slots are explicitly included
+        assert!(session.stitch(10, true).is_some());
         // paint one card slot with a bright square so it stitches
         let mut page = assets::REFERENCE_PAGES_WIN[0].clone();
         for y in 0..45 {
@@ -288,7 +292,7 @@ mod tests {
             }
         }
         session.pages.insert(0, page);
-        let stitched = session.stitch(10).unwrap();
+        let stitched = session.stitch(10, false).unwrap();
         assert!(stitched.width() > 0 && stitched.height() > 0);
     }
 }

--- a/monsterbook/src/wasm.rs
+++ b/monsterbook/src/wasm.rs
@@ -59,11 +59,12 @@ impl WasmSession {
             .map_err(|e| js_error("InternalError", &e.to_string()))
     }
 
-    /// Stitch ingested pages' non-empty cards into a PNG (encoded bytes).
-    pub fn stitch(&self, cards_per_row: u32) -> Result<Vec<u8>, JsValue> {
+    /// Stitch ingested pages' cards into a PNG (encoded bytes). Empty
+    /// (un-caught) card slots are skipped unless `include_empty` is set.
+    pub fn stitch(&self, cards_per_row: u32, include_empty: bool) -> Result<Vec<u8>, JsValue> {
         let img = self
             .inner
-            .stitch(cards_per_row)
+            .stitch(cards_per_row, include_empty)
             .ok_or_else(|| js_error("NoPageFound", "no cards to stitch"))?;
         let mut bytes = Cursor::new(Vec::new());
         DynamicImage::ImageRgba8(img)

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,9 @@
   command = "./netlify-build.sh"
 
 [build.environment]
+  # Override the site's stale NODE_VERSION=12 dashboard setting; vite 5
+  # needs node >= 18.
+  NODE_VERSION = "22"
   # Cache cargo artifacts between builds.
   CARGO_HOME = "/opt/build/cache/cargo"
   RUSTUP_HOME = "/opt/build/cache/rustup"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+# Deploy the Vite/wasm web app (web/), not the legacy rollup app at the
+# repo root. The build image has no Rust toolchain, so bootstrap rustup,
+# the wasm32 target, and wasm-pack before building.
+[build]
+  base = "web"
+  publish = "dist"
+  command = """
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --target wasm32-unknown-unknown && \
+    . "$CARGO_HOME/env" && \
+    curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.13.1/wasm-pack-v0.13.1-x86_64-unknown-linux-musl.tar.gz \
+      | tar -xz --strip-components=1 -C "$CARGO_HOME/bin" --wildcards '*/wasm-pack' && \
+    npm run build:wasm && \
+    npm run build
+  """
+
+[build.environment]
+  # Cache cargo artifacts between builds.
+  CARGO_HOME = "/opt/build/cache/cargo"
+  RUSTUP_HOME = "/opt/build/cache/rustup"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,14 +4,7 @@
 [build]
   base = "web"
   publish = "dist"
-  command = """
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --target wasm32-unknown-unknown && \
-    . "$CARGO_HOME/env" && \
-    curl -sSfL https://github.com/rustwasm/wasm-pack/releases/download/v0.13.1/wasm-pack-v0.13.1-x86_64-unknown-linux-musl.tar.gz \
-      | tar -xz --strip-components=1 -C "$CARGO_HOME/bin" --wildcards '*/wasm-pack' && \
-    npm run build:wasm && \
-    npm run build
-  """
+  command = "./netlify-build.sh"
 
 [build.environment]
   # Cache cargo artifacts between builds.

--- a/web/netlify-build.sh
+++ b/web/netlify-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Netlify build: bootstrap the Rust toolchain, then build the wasm pkg and
+# the Vite site. Run from web/ (the Netlify base directory).
+set -euxo pipefail
+
+WASM_PACK_VERSION=0.13.1
+
+if ! [ -x "$CARGO_HOME/bin/cargo" ]; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    sh -s -- -y --profile minimal --target wasm32-unknown-unknown
+fi
+. "$CARGO_HOME/env"
+rustup target add wasm32-unknown-unknown
+
+if ! [ -x "$CARGO_HOME/bin/wasm-pack" ]; then
+  curl -sSfL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz" |
+    tar -xz --strip-components=1 -C "$CARGO_HOME/bin" --wildcards '*/wasm-pack'
+fi
+
+npm run build:wasm
+npm run build

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -21,8 +21,11 @@
   let rows = [];
   let sortKey = "uid";
   let sortDir = 1;
-  let cardsPerRow = 5;
+  let cardsPerRow = 20;
+  let includeEmpty = true;
   let stitchedUrl = null;
+  let tablePage = 0;
+  const PAGE_SIZE = 40;
   let dragging = false;
   let busy = 0;
   let fileInput;
@@ -32,6 +35,12 @@
     const va = a[sortKey], vb = b[sortKey];
     return (va < vb ? -1 : va > vb ? 1 : 0) * sortDir;
   });
+  $: tablePages = Math.max(1, Math.ceil(sortedRows.length / PAGE_SIZE));
+  $: tablePage = Math.min(tablePage, tablePages - 1);
+  $: pagedRows = sortedRows.slice(
+    tablePage * PAGE_SIZE,
+    (tablePage + 1) * PAGE_SIZE,
+  );
 
   function notify(message) {
     notices = [...notices, { id: noticeId++, message }];
@@ -54,7 +63,7 @@
   async function restitch() {
     let png;
     try {
-      png = await client.stitch(cardsPerRow);
+      png = await client.stitch(cardsPerRow, includeEmpty);
     } catch (err) {
       // The wasm session has nothing to stitch until a page is ingested.
       if (err?.kind === "NoPageFound") {
@@ -71,8 +80,22 @@
   async function ingestBlob(blob, label) {
     busy++;
     try {
-      const buffer = await blob.arrayBuffer();
-      await client.addScreenshot(buffer);
+      // Decode in the browser (handles webp/avif/anything the browser can
+      // render, which the wasm-side image crate cannot), then hand raw RGBA
+      // to the session. Fall back to wasm-side decoding if that fails.
+      try {
+        const bitmap = await createImageBitmap(blob);
+        const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+        const ctx = canvas.getContext("2d");
+        ctx.drawImage(bitmap, 0, 0);
+        const { data } = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+        bitmap.close();
+        await client.addBitmap(canvas.width, canvas.height, data.buffer);
+      } catch (decodeErr) {
+        if (decodeErr?.kind) throw decodeErr; // session error, not a decode failure
+        const buffer = await blob.arrayBuffer();
+        await client.addScreenshot(buffer);
+      }
     } catch (err) {
       notify(`${label}: ${err?.kind ?? "error"}${err?.message ? ` (${err.message})` : ""}`);
     } finally {
@@ -128,6 +151,11 @@
 
 <main class:dragging>
   <h1>Monster Book Stitcher</h1>
+  <p>
+    This app transcribes in-game screenshots of the Monster Book in
+    MapleLegends to help plan and track card hunting. All processing occurs
+    on-device and can be run offline.
+  </p>
   <p class="muted">
     Add screenshots of your monster book pages: choose files, drag and drop
     them anywhere on the page, or paste from the clipboard.
@@ -168,6 +196,30 @@
   </div>
 
   {#if rows.length}
+    <h2>Stitched image</h2>
+    <div class="stitch-controls">
+      <label>
+        Cards per row
+        <input
+          type="number"
+          min="1"
+          max="40"
+          bind:value={cardsPerRow}
+          on:change={onCardsPerRowChange}
+        />
+      </label>
+      <label>
+        <input type="checkbox" bind:checked={includeEmpty} on:change={restitch} />
+        Include empty cards
+      </label>
+    </div>
+    {#if stitchedUrl}
+      <p>
+        <a href={stitchedUrl} download="monsterbook.png"><button>Download PNG</button></a>
+      </p>
+      <img class="stitched" src={stitchedUrl} alt="Stitched monster book" />
+    {/if}
+
     <h2>Cards</h2>
     <div class="table-wrap">
       <table>
@@ -181,31 +233,37 @@
           </tr>
         </thead>
         <tbody>
-          {#each sortedRows as row (row.uid)}
+          {#each pagedRows as row (row.uid)}
             <tr><td>{row.uid}</td><td>{row.name}</td><td>{row.count}</td></tr>
           {/each}
         </tbody>
       </table>
     </div>
-
-    <h2>Stitched image</h2>
-    <label>
-      Cards per row
-      <input
-        type="number"
-        min="1"
-        max="20"
-        bind:value={cardsPerRow}
-        on:change={onCardsPerRowChange}
-      />
-    </label>
-    {#if stitchedUrl}
-      <p>
-        <a href={stitchedUrl} download="monsterbook.png"><button>Download PNG</button></a>
-      </p>
-      <img class="stitched" src={stitchedUrl} alt="Stitched monster book" />
-    {/if}
+    <div class="pager">
+      <button disabled={tablePage === 0} on:click={() => tablePage--}>‹ Prev</button>
+      <span class="muted">
+        {tablePage + 1} / {tablePages} ({sortedRows.length} cards)
+      </span>
+      <button disabled={tablePage >= tablePages - 1} on:click={() => tablePage++}>Next ›</button>
+    </div>
   {/if}
+
+  <footer class="muted">
+    <p>
+      The source code can be found on GitHub at
+      <a href="https://github.com/geospiza-fortis/monsterbook"
+        >geospiza-fortis/monsterbook</a
+      >. The monster and map information is taken from the
+      <a
+        href="https://forum.maplelegends.com/index.php?threads/monster-book-efficient-farming-guide.23984"
+        >Monster Book Efficient Farming Guide</a
+      >
+      by Precel and Bambo (<a
+        href="https://docs.google.com/spreadsheets/d/1ohipSCqwiyyOdqNTWrTzDNGUtYJOojfk9qbVHSl70l0/edit#gid=1847158424"
+        >link</a
+      >).
+    </p>
+  </footer>
 </main>
 
 <style>
@@ -309,6 +367,32 @@
     color: var(--fg);
     border: 1px solid var(--border);
     border-radius: 6px;
+  }
+  .pager {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+  }
+  .pager button:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .stitch-controls {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.75rem;
+  }
+  footer {
+    margin-top: 3rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.9rem;
+  }
+  footer a {
+    color: var(--accent);
   }
   .stitched {
     max-width: 100%;

--- a/web/src/lib/mock-session.js
+++ b/web/src/lib/mock-session.js
@@ -90,7 +90,7 @@ export class Session {
     return rows;
   }
 
-  stitch(cardsPerRow) {
+  stitch(cardsPerRow, includeEmpty = false) {
     // The real wasm module returns PNG bytes synchronously; the mock draws a
     // placeholder grid on an OffscreenCanvas. This is async, so callers should
     // `await` the result (harmless once the real module is sync).

--- a/web/src/lib/session-client.js
+++ b/web/src/lib/session-client.js
@@ -34,4 +34,5 @@ export const addBitmap = (width, height, buffer) =>
   call({ op: "add_bitmap", width, height, buffer }, [buffer]);
 export const missing = () => call({ op: "missing" });
 export const transcribe = () => call({ op: "transcribe" });
-export const stitch = (cardsPerRow) => call({ op: "stitch", cardsPerRow });
+export const stitch = (cardsPerRow, includeEmpty = false) =>
+  call({ op: "stitch", cardsPerRow, includeEmpty });

--- a/web/src/lib/worker.js
+++ b/web/src/lib/worker.js
@@ -46,7 +46,10 @@ self.onmessage = async (event) => {
         result = session.transcribe();
         break;
       case "stitch": {
-        const png = await session.stitch(event.data.cardsPerRow);
+        const png = await session.stitch(
+          event.data.cardsPerRow,
+          event.data.includeEmpty,
+        );
         result = png.buffer;
         transfer = [png.buffer];
         break;

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -6,4 +6,7 @@ export default defineConfig({
   // The session worker uses dynamic import (wasm vs mock), which requires
   // code-splitting; the default iife worker format does not support it.
   worker: { format: "es" },
+  // Listen on all interfaces and skip the Host-header check so the dev
+  // server is reachable from other machines on the LAN.
+  server: { host: true, allowedHosts: true },
 });


### PR DESCRIPTION
## Summary
- Decode uploaded images in the browser (`createImageBitmap` + `OffscreenCanvas`) and ingest raw RGBA via the existing `add_bitmap` op, fixing `DecodeError` on webp uploads — the wasm-side `image` crate (0.23) cannot decode lossless webp. Wasm-side `add_screenshot` decoding remains as a fallback.
- Add an `include_empty` flag through `stitch_page_cards` → `Session::stitch` → the wasm binding, so empty (un-caught) card slots stitch as gray frames showing what's missing. On by default in the web UI via a checkbox. Grid slots past each page's `card_count` are never stitched.
- Default the stitch to 20 cards per row and move it above the cards table.
- Paginate the cards table (40 rows per page with prev/next).
- Restore the intro flavor text and the data-attribution footer (Monster Book Efficient Farming Guide by Precel and Bambo) from the old app.
- Expose the Vite dev server on the LAN (`host: true`, `allowedHosts: true`; dev-only).

## Deployment
**Merging this repoints production at monsterbook.netlify.app from the legacy rollup app to the new web/ app.**
- `netlify.toml` overrides the 2020-era dashboard settings: base `web/`, publish `dist`, command `./netlify-build.sh`.
- `web/netlify-build.sh` bootstraps rustup + the wasm32 target + wasm-pack (cached under `/opt/build/cache` between builds), then runs `build:wasm` and `vite build`.
- `NODE_VERSION=22` is pinned in the toml; the dashboard still had `NODE_VERSION=12` from 2020, which broke vite 5. The stale dashboard vars can be deleted after merge.
- Verified: the deploy preview builds and serves the new app end-to-end.

## Testing
- `cargo test --no-default-features --features wasm`: 21/21 pass (includes a new include-empty stitch assertion).
- Verified end-to-end in the browser with 26 webp and 26 png screenshots: all pages ingest, 396 cards transcribe, stitched output includes empty frames in page order with no phantom trailing slots.